### PR TITLE
Correcting the handling of services that have inherited properties

### DIFF
--- a/bard.js
+++ b/bard.js
@@ -505,8 +505,15 @@
      */
     function mockService(service, config) {
 
-        var serviceKeys = Object.keys(service);
-        var configKeys  = Object.keys(config);
+        var serviceKeys = [];
+        for (var key in service) {
+            serviceKeys.push(key);
+        }
+        
+        var configKeys = [];
+        for (var key in config) {
+            configKeys.push(key);
+        }
 
         angular.forEach(serviceKeys, function(key) {
             var value = configKeys.indexOf(key) > -1 ?

--- a/dist/bard.js
+++ b/dist/bard.js
@@ -512,8 +512,15 @@
      */
     function mockService(service, config) {
 
-        var serviceKeys = Object.keys(service);
-        var configKeys  = Object.keys(config);
+        var serviceKeys = [];
+        for (var key in service) {
+            serviceKeys.push(key);
+        }
+        
+        var configKeys = [];
+        for (var key in config) {
+            configKeys.push(key);
+        }
 
         angular.forEach(serviceKeys, function(key) {
             var value = configKeys.indexOf(key) > -1 ?

--- a/tests/bard.mockService.spec.js
+++ b/tests/bard.mockService.spec.js
@@ -56,6 +56,11 @@ describe('bard.mockService', function() {
         it('does not have a `doWork5`', function() {
             expect(service).to.not.have.property('doWork5');
         });
+        
+        it('`doWorkProto` return the "real" results', function() {
+            var results = service.doWorkProto();
+            expect(results).to.be.true;
+        });
 
         it('`isActive` should be true', function() {
             expect(service.isActive).to.be.true;
@@ -119,6 +124,13 @@ describe('bard.mockService', function() {
                 });
             // verify `doWork5` is a spy
             expect(service.doWork5).to.have.been.called;
+            flush();
+        });
+        
+        it('`doWorkProto` returns `_default` value', function() {
+            service.doWorkProto(1, 2).then(expectEmptyArray);
+            // verify `doWork3` is a spy
+            expect(service.doWorkProto).to.have.been.calledWith(1, 2);
             flush();
         });
 
@@ -187,9 +199,17 @@ describe('bard.mockService', function() {
 
     ///// helpers /////
 
-    // create the exampel DoWork service from bard.mockService usage doc
+    // create the example DoWork service from bard.mockService usage doc
     function getDoWorkService() {
-        return {
+        var doWorkParent = {
+            doWorkProto: function() {
+                return true;
+            }
+        }
+        
+        var doWorkService = Object.create(doWorkParent)
+        
+        angular.extend(doWorkService, {
             doWork1:  function doWork1(a, b) {
                     return $q.when([].slice.apply(arguments));
                 },
@@ -207,7 +227,9 @@ describe('bard.mockService', function() {
                 return 'Hi from doWork4';
             },
             isActive: true
-        };
+        });
+        
+        return doWorkService;
     }
 
     function expectEmptyArray(results) {


### PR DESCRIPTION
Object.keys returns only an object's own properties. I ran into an issue where a service was using inheritance internally and the mockService function would not overwrite the inherited properties with _default. Explicitly specifying the inherited property worked but _default did not.

Using the 'for (var key in object)' syntax traverses the prototype chain and allows mockService to overwrite inherited properties not explicitly called out in the config with _default.
