### PR TITLE
Prevent bower to ask questions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "init": "npm install",
-    "install": "bower install"
+    "install": "bower --config.interactive=false install"
   },
   "dependencies": {
     "sinon": ">=1.12.2"


### PR DESCRIPTION
It is useful when using it in a CI environment. (http://stackoverflow.com/questions/22387857/stop-bower-from-asking-for-statistics-when-installing/22639444#22639444)
