### PR TITLE
Stub Replacement Funcs

### DIFF
--- a/bard.js
+++ b/bard.js
@@ -554,7 +554,7 @@
 
             if (typeof service[key] === 'function') {
                 if (typeof value === 'function') {
-                    service[key] = value;
+                    sinon.stub(service, key, value);
                 } else {
                     sinon.stub(service, key, function() {
                         return value;


### PR DESCRIPTION
Changed the mockService function to actually sinon.stub provided replacement functions rather than just overwriting the function with the replacement function. This allows "dynamic" spying in multiple call scenarios.

Resolves Issue #18
