### PR TITLE
mockService now creates sinon stub instead of spy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 bardjs Change Log
 ===================
+### 0.1.9
+- Changed verifyNoOutstandingHttpRequests to wrap its verification in a try/catch so mocha can be informed about the error in a nice way that doesn't halt the test suite
+- Changed the mockService function to create a stub instead of a spy when the value of a config obj property is a non-function value. This makes it possible to dynamically configure the stub while testing
+
 ### 0.1.8
 - no functional changes.
 - reversed 0.1.7. Apparently [peerDependecies are a horrible idea](https://github.com/npm/npm/issues/5080) and have been deprecated. It also seems that bardjs is DIRECTLY dependent on sinon so it's back to being a dependency.

--- a/bard.js
+++ b/bard.js
@@ -629,9 +629,17 @@
      *  For use with ngMocks; doesn't work for async server integration tests
      */
     function verifyNoOutstandingHttpRequests () {
-        afterEach(angular.mock.inject(function($httpBackend) {
-            $httpBackend.verifyNoOutstandingExpectation();
-            $httpBackend.verifyNoOutstandingRequest();
+        afterEach(angular.mock.inject(function ($httpBackend) {
+            try {
+                $httpBackend.verifyNoOutstandingExpectation();
+                $httpBackend.verifyNoOutstandingRequest();
+            } catch (e) {
+                if (e instanceof Error) {
+                    this.test.error(e); //signal error to mocha - see https://github.com/mochajs/mocha/wiki/Conditionally-failing-tests-in-afterEach()-hooks
+                } else {
+                    throw e; //nothing we can do - this will halt the suite as long as https://github.com/mochajs/mocha/issues/1635 is not fixed
+                }
+            }
         }));
     }
 

--- a/bard.js
+++ b/bard.js
@@ -556,9 +556,7 @@
                 if (typeof value === 'function') {
                     sinon.stub(service, key, value);
                 } else {
-                    sinon.stub(service, key, function() {
-                        return value;
-                    });
+                    sinon.stub(service, key).returns(value);
                 }
             } else {
                 service[key] = value;

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "bardjs",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Spec helpers for testing angular v.1.x apps with Mocha, Jasmine or QUnit",
   "authors": [
     "John Papa",

--- a/dist/bard-ngRouteTester.js
+++ b/dist/bard-ngRouteTester.js
@@ -1,7 +1,7 @@
 /**
  * bardjs - Spec helpers for testing angular v.1.x apps with Mocha, Jasmine or QUnit
  * @authors John Papa,Ward Bell
- * @version v0.1.8
+ * @version v0.1.9
  * @link https://github.com/wardbell/bardjs
  * @license MIT
  */

--- a/dist/bard.js
+++ b/dist/bard.js
@@ -1,7 +1,7 @@
 /**
  * bardjs - Spec helpers for testing angular v.1.x apps with Mocha, Jasmine or QUnit
  * @authors John Papa,Ward Bell
- * @version v0.1.8
+ * @version v0.1.9
  * @link https://github.com/wardbell/bardjs
  * @license MIT
  */
@@ -561,11 +561,9 @@
 
             if (typeof service[key] === 'function') {
                 if (typeof value === 'function') {
-                    service[key] = value;
+                    sinon.stub(service, key, value);
                 } else {
-                    sinon.stub(service, key, function() {
-                        return value;
-                    });
+                    sinon.stub(service, key).returns(value);
                 }
             } else {
                 service[key] = value;
@@ -638,9 +636,17 @@
      *  For use with ngMocks; doesn't work for async server integration tests
      */
     function verifyNoOutstandingHttpRequests () {
-        afterEach(angular.mock.inject(function($httpBackend) {
-            $httpBackend.verifyNoOutstandingExpectation();
-            $httpBackend.verifyNoOutstandingRequest();
+        afterEach(angular.mock.inject(function ($httpBackend) {
+            try {
+                $httpBackend.verifyNoOutstandingExpectation();
+                $httpBackend.verifyNoOutstandingRequest();
+            } catch (e) {
+                if (e instanceof Error) {
+                    this.test.error(e); //signal error to mocha - see https://github.com/mochajs/mocha/wiki/Conditionally-failing-tests-in-afterEach()-hooks
+                } else {
+                    throw e; //nothing we can do - this will halt the suite as long as https://github.com/mochajs/mocha/issues/1635 is not fixed
+                }
+            }
         }));
     }
 

--- a/dist/bard.min.js
+++ b/dist/bard.min.js
@@ -1,7 +1,7 @@
 /**
  * bardjs - Spec helpers for testing angular v.1.x apps with Mocha, Jasmine or QUnit
  * @authors John Papa,Ward Bell
- * @version v0.1.8
+ * @version v0.1.9
  * @link https://github.com/wardbell/bardjs
  * @license MIT
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bardjs",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Spec helpers for testing angular v.1.x apps with Mocha, Jasmine or QUnit",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Each property value of the config obj that is a non-function value can be created as a sinon stub. This makes it possible to dynamically configure the stub further while testing, to e.g. make conditional returns based on argument values (see http://sinonjs.org/docs/#stubs-api).
