### PR TITLE
Add false parameter to verifyNoOutstandingExpectation() method

### DIFF
--- a/bard.js
+++ b/bard.js
@@ -632,7 +632,7 @@
      */
     function verifyNoOutstandingHttpRequests () {
         afterEach(angular.mock.inject(function($httpBackend) {
-            $httpBackend.verifyNoOutstandingExpectation();
+            $httpBackend.verifyNoOutstandingExpectation(false);
             $httpBackend.verifyNoOutstandingRequest();
         }));
     }


### PR DESCRIPTION
Fixes the 'Error: [$rootScope:inprog] $digest already in progress' to make it skip the unnecessary $digest cycle.
