### PR TITLE
Replace hardcoded URL for sinon with version number ^1.15.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "angular": ">=1.3.8",
     "angular-mocks": ">=1.3.8",
-    "sinon": "http://sinonjs.org/releases/sinon-1.15.0.js"
+    "sinon": "^1.15.0"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
URL "http://sinonjs.org/releases/sinon-1.15.0.js" gives a 404 now. Providing "^1.15.0" as version number resolves currently to sinon#1.17.7 and installs correctly.